### PR TITLE
"checkers" package missing from source distribution (sdist)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,15 @@ setuptools.setup(
     author='Rocio Aramberri Schegel',
     author_email='rocioaramberri@schegel.net',
     url='http://github.com/rocioar/flake8-django',
-    py_modules=['flake8_django', 'issues', 'checkers'],
+    py_modules=[
+        'flake8_django',
+        'checkers',
+        'checkers.checker',
+        'checkers.issue',
+        'checkers.model_fields',
+        'checkers.render',
+        'checkers.urls',
+    ],
     entry_points={
         'flake8.extension': [
             'DJ0 = flake8_django:DjangoStyleChecker',


### PR DESCRIPTION
When using `py_modules` you have to explicitly specify each and every module that is going to be included in the source distribution (i.e. the tar ball).

All checkers are missing in the `v0.0.2` release.

Fixes #15