### PR TITLE
Add checker DJ06 for ModelForm exclude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+dev
+---
+
+**Improvements**
+
+- Added `DJ06` check for ModelForm, should not use exclude
+
 0.0.3 (2018-10-03)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ $ pytest --cov=.
 | `DJ03` | Using locals() in render function is not recommended, use explicit arguments |
 | `DJ04` | Using dashes in url names is discouraged, use underscores instead |
 | `DJ05` | URLs include() should set a namespace |
+| `DJ06` | ModelForm should not set exclude, instead it should use fields, which is an explicit list of all the fields that should be included in the form |
 
 ## Licence
 

--- a/checkers/__init__.py
+++ b/checkers/__init__.py
@@ -1,6 +1,7 @@
 from .model_fields import ModelFieldChecker
+from .model_form import ModelFormChecker
 from .render import RenderChecker
 from .urls import URLChecker
 
 
-__all__ = ['ModelFieldChecker', 'RenderChecker', 'URLChecker']
+__all__ = ['ModelFieldChecker', 'ModelFormChecker', 'RenderChecker', 'URLChecker']

--- a/checkers/model_form.py
+++ b/checkers/model_form.py
@@ -1,0 +1,60 @@
+import ast
+
+from .checker import Checker
+from .issue import Issue
+
+
+class DJ06(Issue):
+    code = 'DJ06'
+    description = 'ModelForm.Meta should not set "exclude", set "fields" instead'
+
+
+class ModelFormChecker(Checker):
+
+    def checker_applies(self, node):
+        for base in node.bases:
+            is_model_form = self.is_model_form_attribute(base) or self.is_model_form_name(base)
+            if is_model_form:
+                return True
+        return False
+
+    def is_model_form_name(self, base):
+        """
+        Return True if class is defined as Form(ModelForm)
+        """
+        return (
+            isinstance(base, ast.Name) and
+            base.id == 'ModelForm'
+        )
+
+    def is_model_form_attribute(self, base):
+        """
+        Return True if class is defined as Form(models.ModelForm)
+        """
+        return (
+            isinstance(base, ast.Attribute) and
+            isinstance(base.value, ast.Name) and
+            base.value.id == 'models' and base.attr == 'ModelForm'
+        )
+
+    def run(self, node):
+        """
+        Captures the use of exclude in ModelForm Meta
+        """
+        if not self.checker_applies(node):
+            return
+
+        for body in node.body:
+            if not isinstance(body, ast.ClassDef):
+                continue
+            for element in body.body:
+                if not isinstance(element, ast.Assign):
+                    continue
+                for target in element.targets:
+                    if target.id == 'exclude':
+                        return [
+                            DJ06(
+                                lineno=node.lineno,
+                                col=node.col_offset
+                            )
+                        ]

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setuptools.setup(
         'checkers.checker',
         'checkers.issue',
         'checkers.model_fields',
+        'checkers.model_form',
         'checkers.render',
         'checkers.urls',
     ],

--- a/tests/fixtures/model_form_exclude.py
+++ b/tests/fixtures/model_form_exclude.py
@@ -1,0 +1,15 @@
+class User(models.ModelForm):
+    name = models.CharField(max_length=255)
+    email = models.EmailField()
+
+    class Meta:
+        model = User
+        exclude = ('name',)
+
+class User2(ModelForm):
+    name = models.CharField(max_length=255)
+    email = models.EmailField()
+
+    class Meta:
+        model = User2
+        exclude = ('name',)

--- a/tests/fixtures/model_form_fields.py
+++ b/tests/fixtures/model_form_fields.py
@@ -1,0 +1,12 @@
+from django import models
+
+class User(models.ModelForm):
+    name = models.CharField(max_length=255)
+    email = models.EmailField()
+
+    class Meta:
+        model = User
+        fields = ('name',)
+
+        def test_method_doesnt_error(self):
+            pass

--- a/tests/test_model_form.py
+++ b/tests/test_model_form.py
@@ -1,0 +1,13 @@
+from .utils import run_check, load_fixture_file
+
+
+def test_model_form_doesnt_set_exclude_fails():
+    code = load_fixture_file('model_form_exclude.py')
+    assert len(run_check(code)) == 2
+    assert 'DJ06' in run_check(code)[0][2]
+    assert 'DJ06' in run_check(code)[1][2]
+
+
+def test_model_form_doesnt_set_exclude_success():
+    code = load_fixture_file('model_form_fields.py')
+    assert len(run_check(code)) == 0

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 import ast
+import os
 
 from flake8_django import DjangoStyleChecker
 
@@ -7,3 +8,12 @@ def run_check(code):
     tree = ast.parse(code)
     checker = DjangoStyleChecker(tree, None)
     return list(checker.run())
+
+
+def load_fixture_file(filename):
+    path = os.path.join(
+        os.path.dirname(__file__),
+        'fixtures',
+        filename
+    )
+    return open(path).read()


### PR DESCRIPTION
Adds check to see if exclude attribute exists in `Meta` class inside the `ModelForm`. If it does, it throughs an error and it recommends to use `fields` attribute instead.

Setting `fields` requires the developer to be explicit about the fields that should be displayed in the form. In the case of `exclude`, developer only has to add the fields that wants excluded, which could bring problems in the future if there is a new field added and it's accidentally shown on the form.

Fixes #5