### PR TITLE
Add checker DJ07 for ModelForm Meta.fields should not be '__all__'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ dev
 **Improvements**
 
 - Added `DJ06` check for ModelForm, should not use exclude
+- Added `DJ07` check for `ModelForm.META`, should not set fields to `'__all__'`
 
 0.0.3 (2018-10-03)
 ------------------

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ $ pytest --cov=.
 | `DJ04` | Using dashes in url names is discouraged, use underscores instead |
 | `DJ05` | URLs include() should set a namespace |
 | `DJ06` | ModelForm should not set exclude, instead it should use fields, which is an explicit list of all the fields that should be included in the form |
+| `DJ07` | ModelForm.Meta should not set fields to '__all__'|
 
 ## Licence
 

--- a/tests/fixtures/model_form_fields_all.py
+++ b/tests/fixtures/model_form_fields_all.py
@@ -1,15 +1,16 @@
-class User(models.ModelForm):
-    name = models.CharField(max_length=255)
-    email = models.EmailField()
-
-    class Meta:
-        model = User
-        exclude = ('name',)
-
-class User2(ModelForm):
+class User3(ModelForm):
     name = models.CharField(max_length=255)
     email = models.EmailField()
 
     class Meta:
         model = User2
-        exclude = ('name',)
+        fields = '__all__'
+
+
+class User4(ModelForm):
+    name = models.CharField(max_length=255)
+    email = models.EmailField()
+
+    class Meta:
+        model = User2
+        fields = b'__all__'

--- a/tests/test_model_form.py
+++ b/tests/test_model_form.py
@@ -11,3 +11,10 @@ def test_model_form_doesnt_set_exclude_fails():
 def test_model_form_doesnt_set_exclude_success():
     code = load_fixture_file('model_form_fields.py')
     assert len(run_check(code)) == 0
+
+
+def test_model_form_doesnt_set_fields_dunder_all():
+    code = load_fixture_file('model_form_fields_all.py')
+    assert len(run_check(code)) == 2
+    assert 'DJ07' in run_check(code)[0][2]
+    assert 'DJ07' in run_check(code)[1][2]

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py34,py35,py36,py37
 [flake8]
 max-line-length = 120
+exclude = tests/fixtures/*
 [testenv]
 deps = pytest
 commands =


### PR DESCRIPTION
Adds check to see if fields attribute has the value '__all__' in Meta class inside the ModelForm. If it does, it throughs an error and it recommends to set them explicitly as a list.

Fixes #20 