### PR TITLE
Remove unnecessary testenvs in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,11 +6,3 @@ max-line-length = 120
 deps = pytest
 commands =
     pytest
-[testenv:py34]
-basepython = python3.4
-[testenv:py35]
-basepython = python3.5
-[testenv:py36]
-basepython = python3.6
-[testenv:py37]
-basepython = python3.7


### PR DESCRIPTION
This configuration was needed when using travis-ci, but we are not using it anymore