### PR TITLE
Add checker DJ08 for database related models should set __str__ 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ $ pytest --cov=.
 | `DJ04` | Using dashes in url names is discouraged, use underscores instead |
 | `DJ05` | URLs include() should set a namespace |
 | `DJ06` | ModelForm should not set exclude, instead it should use fields, which is an explicit list of all the fields that should be included in the form |
-| `DJ07` | ModelForm.Meta should not set fields to '__all__'|
-| `DJ08` | Models that inherits from django db models should set '__str__'|
+| `DJ07` | ModelForm.Meta should not set fields to `__all__`|
+| `DJ08` | Models that inherits from django db models should set `__str__`|
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ $ pytest --cov=.
 | `DJ05` | URLs include() should set a namespace |
 | `DJ06` | ModelForm should not set exclude, instead it should use fields, which is an explicit list of all the fields that should be included in the form |
 | `DJ07` | ModelForm.Meta should not set fields to '__all__'|
+| `DJ08` | Models that inherits from django db models should set '__str__'|
 
 ## Licence
 

--- a/checkers/__init__.py
+++ b/checkers/__init__.py
@@ -1,7 +1,8 @@
+from .model_dunder_str import ModelDunderStrMissingChecker
 from .model_fields import ModelFieldChecker
 from .model_form import ModelFormChecker
 from .render import RenderChecker
 from .urls import URLChecker
 
 
-__all__ = ['ModelFieldChecker', 'ModelFormChecker', 'RenderChecker', 'URLChecker']
+__all__ = ['ModelDunderStrMissingChecker', 'ModelFieldChecker', 'ModelFormChecker', 'RenderChecker', 'URLChecker']

--- a/checkers/base_model_checker.py
+++ b/checkers/base_model_checker.py
@@ -1,0 +1,30 @@
+import ast
+
+from .checker import Checker
+
+
+class BaseModelChecker(Checker):
+    """
+    Base class for checkers that must lookup for Model like nodes.
+    """
+
+    model_name_lookup = None
+
+    def is_model_name_lookup(self, base):
+        """
+        Return True if class is defined as the respective model name lookup declaration
+        """
+        return (
+            isinstance(base, ast.Name) and
+            base.id == self.model_name_lookup
+        )
+
+    def is_models_name_lookup_attribute(self, base):
+        """
+        Return True if class is defined as the respective model name lookup declaration
+        """
+        return (
+            isinstance(base, ast.Attribute) and
+            isinstance(base.value, ast.Name) and
+            base.value.id == 'models' and base.attr == self.model_name_lookup
+        )

--- a/checkers/model_dunder_str.py
+++ b/checkers/model_dunder_str.py
@@ -1,6 +1,6 @@
 import ast
 
-from .checker import Checker
+from .base_model_checker import BaseModelChecker
 from .issue import Issue
 
 
@@ -9,26 +9,14 @@ class DJ08(Issue):
     description = '__str__ method should be present in all db models'
 
 
-class ModelDunderStrMissingChecker(Checker):
+class ModelDunderStrMissingChecker(BaseModelChecker):
+    model_name_lookup = 'Model'
 
     def checker_applies(self, node):
         for base in node.bases:
-            if self.is_model_name(base) or self.is_models_attribute(base):
+            if self.is_model_name_lookup(base) or self.is_models_name_lookup_attribute(base):
                 return True
         return False
-
-    def is_model_name(self, base):
-        return (
-            isinstance(base, ast.Name) and
-            base.id == 'Model'
-        )
-
-    def is_models_attribute(self, base):
-        return (
-            isinstance(base, ast.Attribute) and
-            isinstance(base.value, ast.Name) and
-            base.value.id == 'models' and base.attr == 'Model'
-        )
 
     def is_dunder_str_method(self, element):
         return (

--- a/checkers/model_dunder_str.py
+++ b/checkers/model_dunder_str.py
@@ -1,0 +1,51 @@
+import ast
+
+from .checker import Checker
+from .issue import Issue
+
+
+class DJ08(Issue):
+    code = 'DJ08'
+    description = '__str__ method should be present in all db models'
+
+
+class ModelDunderStrMissingChecker(Checker):
+
+    def checker_applies(self, node):
+        for base in node.bases:
+            if self.is_model_name(base) or self.is_models_attribute(base):
+                return True
+        return False
+
+    def is_model_name(self, base):
+        return (
+            isinstance(base, ast.Name) and
+            base.id == 'Model'
+        )
+
+    def is_models_attribute(self, base):
+        return (
+            isinstance(base, ast.Attribute) and
+            isinstance(base.value, ast.Name) and
+            base.value.id == 'models' and base.attr == 'Model'
+        )
+
+    def is_dunder_str_method(self, element):
+        return (
+            isinstance(element, ast.FunctionDef) and
+            element.name == '__str__'
+        )
+
+    def run(self, node):
+        if not self.checker_applies(node):
+            return
+
+        if not any(self.is_dunder_str_method(elem) for elem in node.body):
+            return [
+                DJ08(
+                    lineno=node.lineno,
+                    col=node.col_offset
+                )
+            ]
+
+        return []

--- a/checkers/model_form.py
+++ b/checkers/model_form.py
@@ -1,6 +1,6 @@
 import ast
 
-from .checker import Checker
+from .base_model_checker import BaseModelChecker
 from .issue import Issue
 
 
@@ -14,33 +14,15 @@ class DJ07(Issue):
     description = "ModelForm.Meta should not set fields to '__all__'"
 
 
-class ModelFormChecker(Checker):
+class ModelFormChecker(BaseModelChecker):
+    model_name_lookup = 'ModelForm'
 
     def checker_applies(self, node):
         for base in node.bases:
-            is_model_form = self.is_model_form_attribute(base) or self.is_model_form_name(base)
+            is_model_form = self.is_model_name_lookup(base) or self.is_models_name_lookup_attribute(base)
             if is_model_form:
                 return True
         return False
-
-    def is_model_form_name(self, base):
-        """
-        Return True if class is defined as Form(ModelForm)
-        """
-        return (
-            isinstance(base, ast.Name) and
-            base.id == 'ModelForm'
-        )
-
-    def is_model_form_attribute(self, base):
-        """
-        Return True if class is defined as Form(models.ModelForm)
-        """
-        return (
-            isinstance(base, ast.Attribute) and
-            isinstance(base.value, ast.Name) and
-            base.value.id == 'models' and base.attr == 'ModelForm'
-        )
 
     def is_string_dunder_all(self, element):
         """

--- a/flake8_django.py
+++ b/flake8_django.py
@@ -1,6 +1,6 @@
 import ast
 
-from checkers import ModelFieldChecker, ModelFormChecker, URLChecker, RenderChecker
+from checkers import ModelDunderStrMissingChecker, ModelFieldChecker, ModelFormChecker, URLChecker, RenderChecker
 
 __version__ = '0.0.3'
 
@@ -17,6 +17,7 @@ class DjangoStyleFinder(ast.NodeVisitor):
         ],
         'ClassDef': [
             ModelFormChecker(),
+            ModelDunderStrMissingChecker(),
         ]
     }
 

--- a/tests/fixtures/model_dunder_str.py
+++ b/tests/fixtures/model_dunder_str.py
@@ -1,0 +1,30 @@
+from django import models
+from django.models import Model
+
+
+class TestModel1(Model):
+    new_field = models.CharField(max_length=10)
+
+    def __str__(self):
+        return self.new_field
+
+    @property
+    def my_brand_new_property(self):
+        return 1
+
+    def my_beautiful_method(self):
+        return 2
+
+
+class TestModel2(models.Model):
+    new_field = models.CharField(max_length=10)
+
+    def __str__(self):
+        return self.new_field
+
+    @property
+    def my_brand_new_property(self):
+        return 1
+
+    def my_beautiful_method(self):
+        return 2

--- a/tests/fixtures/model_without_dunder_str.py
+++ b/tests/fixtures/model_without_dunder_str.py
@@ -1,0 +1,24 @@
+from django import models
+from django.models import Model
+
+
+class TestModel1(models.Model):
+    new_field = models.CharField(max_length=10)
+
+    @property
+    def my_brand_new_property(self):
+        return 1
+
+    def my_beautiful_method(self):
+        return 2
+
+
+class TestModel2(Model):
+    new_field = models.CharField(max_length=10)
+
+    @property
+    def my_brand_new_property(self):
+        return 1
+
+    def my_beautiful_method(self):
+        return 2

--- a/tests/test_model_dunder_str.py
+++ b/tests/test_model_dunder_str.py
@@ -1,0 +1,13 @@
+from .utils import run_check, load_fixture_file
+
+
+def test_model_without_dunder_str_method_fails():
+    code = load_fixture_file('model_without_dunder_str.py')
+    assert len(run_check(code)) == 2
+    assert 'DJ08' in run_check(code)[0][2]
+    assert 'DJ08' in run_check(code)[1][2]
+
+
+def test_model_with_dunder_str_method_success():
+    code = load_fixture_file('model_dunder_str.py')
+    assert len(run_check(code)) == 0


### PR DESCRIPTION
Adds check to see if classes that inherits from django models overrides the dunder str method. If it does not, it throughs an error and it recommends to set it.

Resolves #14 .

I opened it as a new PR since my log tree got a bit confused.