### PR TITLE
Add option to ignore DJ08 for abstract models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# IntelliJ
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+0.0.5 (2019-05-06)
+------------------
+
+**Improvements**
+
+- Changed `DJ08` check for `__str__` method to ignore abstract models (@denizdogan)
+
 0.0.4 (2019-01-18)
 ------------------
 

--- a/flake8_django/checkers/base_model_checker.py
+++ b/flake8_django/checkers/base_model_checker.py
@@ -10,6 +10,26 @@ class BaseModelChecker(Checker):
 
     model_name_lookup = None
 
+    def _is_abstract_and_set_to_true(self, element):
+        return (
+                isinstance(element, ast.Assign)
+                and element.value.value is True
+                and any(target.id == 'abstract' for target in element.targets)
+        )
+
+    def is_abstract_model(self, base):
+        """
+        Return True if AST node has a Meta class with abstract = True.
+        """
+        # look for "class Meta"
+        for element in base.body:
+            if isinstance(element, ast.ClassDef) and element.name == 'Meta':
+                # look for "abstract = True"
+                for inner_element in element.body:
+                    if self._is_abstract_and_set_to_true(inner_element):
+                        return True
+        return False
+
     def is_model_name_lookup(self, base):
         """
         Return True if class is defined as the respective model name lookup declaration

--- a/flake8_django/checkers/model_dunder_str.py
+++ b/flake8_django/checkers/model_dunder_str.py
@@ -15,7 +15,8 @@ class ModelDunderStrMissingChecker(BaseModelChecker):
     def checker_applies(self, node):
         for base in node.bases:
             if self.is_model_name_lookup(base) or self.is_models_name_lookup_attribute(base):
-                return True
+                if not self.is_abstract_model(node):
+                    return True
         return False
 
     def is_dunder_str_method(self, element):
@@ -35,5 +36,3 @@ class ModelDunderStrMissingChecker(BaseModelChecker):
                     col=node.col_offset
                 )
             ]
-
-        return []

--- a/tests/fixtures/abstract_model_dunder_str.py
+++ b/tests/fixtures/abstract_model_dunder_str.py
@@ -2,8 +2,14 @@ from django import models
 from django.models import Model
 
 
-class TestModel1(models.Model):
+class AbstractTestModel1(Model):
     new_field = models.CharField(max_length=10)
+
+    class Meta:
+        abstract = True
+
+    def __str__(self):
+        return self.new_field
 
     @property
     def my_brand_new_property(self):
@@ -13,8 +19,14 @@ class TestModel1(models.Model):
         return 2
 
 
-class TestModel2(Model):
+class AbstractTestModel2(models.Model):
     new_field = models.CharField(max_length=10)
+
+    class Meta:
+        abstract = True
+
+    def __str__(self):
+        return self.new_field
 
     @property
     def my_brand_new_property(self):
@@ -24,11 +36,14 @@ class TestModel2(Model):
         return 2
 
 
-class TestModel3(Model):
+class AbstractTestModel3(models.Model):
     new_field = models.CharField(max_length=10)
 
     class Meta:
         abstract = False
+
+    def __str__(self):
+        return self.new_field
 
     @property
     def my_brand_new_property(self):

--- a/tests/fixtures/abstract_model_without_dunder_str.py
+++ b/tests/fixtures/abstract_model_without_dunder_str.py
@@ -2,33 +2,25 @@ from django import models
 from django.models import Model
 
 
-class TestModel1(models.Model):
-    new_field = models.CharField(max_length=10)
-
-    @property
-    def my_brand_new_property(self):
-        return 1
-
-    def my_beautiful_method(self):
-        return 2
-
-
-class TestModel2(Model):
-    new_field = models.CharField(max_length=10)
-
-    @property
-    def my_brand_new_property(self):
-        return 1
-
-    def my_beautiful_method(self):
-        return 2
-
-
-class TestModel3(Model):
+class AbstractTestModel1(models.Model):
     new_field = models.CharField(max_length=10)
 
     class Meta:
-        abstract = False
+        abstract = True
+
+    @property
+    def my_brand_new_property(self):
+        return 1
+
+    def my_beautiful_method(self):
+        return 2
+
+
+class AbstractTestModel2(Model):
+    new_field = models.CharField(max_length=10)
+
+    class Meta:
+        abstract = True
 
     @property
     def my_brand_new_property(self):

--- a/tests/test_model_dunder_str.py
+++ b/tests/test_model_dunder_str.py
@@ -3,11 +3,27 @@ from .utils import run_check, load_fixture_file
 
 def test_model_without_dunder_str_method_fails():
     code = load_fixture_file('model_without_dunder_str.py')
-    assert len(run_check(code)) == 2
+    assert len(run_check(code)) == 3
     assert 'DJ08' in run_check(code)[0][2]
     assert 'DJ08' in run_check(code)[1][2]
 
 
 def test_model_with_dunder_str_method_success():
     code = load_fixture_file('model_dunder_str.py')
+    assert len(run_check(code)) == 0
+
+
+def test_abstract_model_without_dunder_str_method_success():
+    """
+    Abstract models without __str__ succeed.
+    """
+    code = load_fixture_file('abstract_model_without_dunder_str.py')
+    assert len(run_check(code)) == 0
+
+
+def test_abstract_model_with_dunder_str_method_success():
+    """
+    Abstract models with __str__ succeed.
+    """
+    code = load_fixture_file('abstract_model_dunder_str.py')
     assert len(run_check(code)) == 0


### PR DESCRIPTION
Since you can't instantiate an abstract Django model, DJ08 raises unexpected warnings for any abstract model that does not implement `__str__`. In my opinion, `__str__` is unnecessary (and possibly even incorrect) to implement on abstract models.

This change adds an option called `--ignore-abstract-models` (turned off by default) which skips the `__str__` check for abstract Django models. Added information to the README and included complete unit tests.

Let me know what you think! 🚀 
