### PR TITLE
Add ModelContentOrder check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# IntelliJ
+.idea

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ $ pytest --cov=.
 | `DJ06` | ModelForm should not set exclude, instead it should use fields, which is an explicit list of all the fields that should be included in the form |
 | `DJ07` | ModelForm.Meta should not set fields to `__all__`|
 | `DJ08` | Models that inherits from django db models should set `__str__`|
+| `DJ09` | Order of model inner classes and standard methods does not follow Django style guide |
 
 ## Licence
 

--- a/flake8_django/checker.py
+++ b/flake8_django/checker.py
@@ -1,6 +1,7 @@
 import ast
 
-from flake8_django.checkers import ModelDunderStrMissingChecker, ModelFieldChecker, ModelFormChecker, URLChecker, RenderChecker
+from flake8_django.checkers import ModelContentOrderChecker, ModelDunderStrMissingChecker, ModelFieldChecker, \
+    ModelFormChecker, URLChecker, RenderChecker
 
 __version__ = '0.0.3'
 
@@ -18,6 +19,7 @@ class DjangoStyleFinder(ast.NodeVisitor):
         'ClassDef': [
             ModelFormChecker(),
             ModelDunderStrMissingChecker(),
+            ModelContentOrderChecker(),
         ]
     }
 

--- a/flake8_django/checkers/__init__.py
+++ b/flake8_django/checkers/__init__.py
@@ -1,3 +1,4 @@
+from .model_content_order import ModelContentOrderChecker
 from .model_dunder_str import ModelDunderStrMissingChecker
 from .model_fields import ModelFieldChecker
 from .model_form import ModelFormChecker
@@ -5,4 +6,4 @@ from .render import RenderChecker
 from .urls import URLChecker
 
 
-__all__ = ['ModelDunderStrMissingChecker', 'ModelFieldChecker', 'ModelFormChecker', 'RenderChecker', 'URLChecker']
+__all__ = ['ModelContentOrderChecker', 'ModelDunderStrMissingChecker', 'ModelFieldChecker', 'ModelFormChecker', 'RenderChecker', 'URLChecker']

--- a/flake8_django/checkers/model_content_order.py
+++ b/flake8_django/checkers/model_content_order.py
@@ -17,7 +17,9 @@ class DJ09(Issue):
 
 
 def is_assignment_call(node):
-    return isinstance(node, Assign) and isinstance(node.value, Call)
+    # check if assigning the return value of a function call to a target which is not in all uppercase letters
+    # (because that would be a constant)
+    return isinstance(node, Assign) and isinstance(node.value, Call) and not node.targets[0].id.isupper()
 
 
 def is_manager_declaration(node):

--- a/flake8_django/checkers/model_content_order.py
+++ b/flake8_django/checkers/model_content_order.py
@@ -1,0 +1,105 @@
+from ast import Assign, Call, ClassDef, FunctionDef
+
+from .base_model_checker import BaseModelChecker
+from .issue import Issue
+
+
+class DJ09(Issue):
+    code = 'DJ09'
+    description = 'Order of model inner classes and standard methods does not follow Django style guide: {elem_type} should come before {before}'
+
+    def __init__(self, elem, elem_type, before):
+        super().__init__(elem.lineno, elem.col_offset, None)
+        self.description = self.description.format(
+            elem_type=elem_type,
+            before=before,
+        )
+
+
+def is_assignment_call(node):
+    return isinstance(node, Assign) and isinstance(node.value, Call)
+
+
+def is_manager_declaration(node):
+    return isinstance(node, Assign) and node.targets[0].id == 'objects'
+
+
+def is_meta_declaration(node):
+    return isinstance(node, ClassDef) and node.name == 'Meta'
+
+
+def is_save_declaration(node):
+    return isinstance(node, FunctionDef) and node.name == 'save'
+
+
+def is_str_declaration(node):
+    return isinstance(node, FunctionDef) and node.name == '__str__'
+
+
+def is_url_declaration(node):
+    return isinstance(node, FunctionDef) and node.name == 'get_absolute_url'
+
+
+class ModelContentOrderChecker(BaseModelChecker):
+    model_name_lookup = 'Model'
+
+    def checker_applies(self, node):
+        for base in node.bases:
+            if self.is_model_name_lookup(base) or self.is_models_name_lookup_attribute(base):
+                return True
+        return False
+
+    def get_elem_linenos(self, node):
+        # expected order of each element type
+        order = [
+            'field declaration',
+            'manager declaration',
+            'Meta class',
+            '__str__ method',
+            'save method',
+            'get_absolute_url method',
+            'custom method',
+        ]
+
+        found_idx = []
+        for elem in node.body:
+            # determine each element type
+            if is_manager_declaration(elem):
+                elem_type = 'manager declaration'
+            elif is_meta_declaration(elem):
+                elem_type = 'Meta class'
+            elif is_str_declaration(elem):
+                elem_type = '__str__ method'
+            elif is_save_declaration(elem):
+                elem_type = 'save method'
+            elif is_url_declaration(elem):
+                elem_type = 'get_absolute_url method'
+            elif isinstance(elem, FunctionDef):
+                elem_type = 'custom method'
+            elif is_assignment_call(elem):
+                # assignment to the return value of a function call is presumed to be a field
+                elem_type = 'field declaration'
+            else:
+                # skip unknowns
+                continue  # pragma: no cover
+
+            # get the expected order of elem_type. find the first index which is greater than elem_idx. if any such
+            # index was found, the element type corresponding to that index should have come before ``elem``.
+            # otherwise, add the index of elem_type to the list of found indices.
+            elem_idx = order.index(elem_type)
+            greater_idx = next((i for i in found_idx if i > elem_idx), -1)
+            if greater_idx > -1:
+                before = order[greater_idx]
+                yield DJ09(
+                    elem,
+                    elem_type,
+                    before,
+                )
+            else:
+                found_idx.append(elem_idx)
+
+    def run(self, node):
+        if not self.checker_applies(node):
+            return
+
+        return list(self.get_elem_linenos(node))

--- a/tests/fixtures/model_content_order.py
+++ b/tests/fixtures/model_content_order.py
@@ -43,6 +43,18 @@ class CustomMethodBeforeStr(models.Model):
         return 'foobar'
 
 
+class ConstantsAreNotFields(models.Model):
+    """
+    Model with an assignment to a constant after __str__.
+    """
+    first_name = models.CharField(max_length=32)
+
+    def __str__(self):
+        pass
+
+    MY_CONSTANT = id(1)
+
+
 class PerfectlyFine(models.Model):
     """
     Model which has everything in perfect order.

--- a/tests/fixtures/model_content_order.py
+++ b/tests/fixtures/model_content_order.py
@@ -1,0 +1,70 @@
+from django.db import models
+
+
+class StrBeforeFieldModel2(models.Model):
+    random_property = 'foo'
+
+    def __str__(self):
+        return ''
+
+
+class StrBeforeFieldModel(models.Model):
+    """
+    Model with __str__ before fields.
+    """
+
+    def __str__(self):
+        return 'foobar'
+
+    first_name = models.CharField(max_length=32)
+
+
+class ManagerBeforeField(models.Model):
+    """
+    Model with manager before fields.
+    """
+    objects = 'manager'
+
+    def __str__(self):
+        return 'foobar'
+
+    first_name = models.CharField(max_length=32)
+
+
+class CustomMethodBeforeStr(models.Model):
+    """
+    Model with a custom method before __str__.
+    """
+
+    def my_method(self):
+        pass
+
+    def __str__(self):
+        return 'foobar'
+
+
+class PerfectlyFine(models.Model):
+    """
+    Model which has everything in perfect order.
+    """
+    first_name = models.CharField(max_length=32)
+    objects = 'manager'
+
+    class Meta:
+        pass
+
+    def __str__(self):
+        return 'Perfectly fine!'
+
+    def save(self, **kwargs):
+        super(PerfectlyFine, self).save(**kwargs)
+
+    def get_absolute_url(self):
+        return 'http://%s' % self
+
+    def my_method(self):
+        pass
+
+    @property
+    def random_property(self):
+        return '%s' % self

--- a/tests/test_model_content_order.py
+++ b/tests/test_model_content_order.py
@@ -1,0 +1,10 @@
+from .utils import run_check, load_fixture_file
+
+
+def test_model_content_order_succeeds():
+    code = load_fixture_file('model_content_order.py')
+    issues = list(map(lambda x: x[2], run_check(code)))
+    assert len(issues) == 3
+    assert 'DJ09' in issues[0] and 'before __str__' in issues[0]
+    assert 'DJ09' in issues[1] and 'before manager' in issues[1]
+    assert 'DJ09' in issues[2] and 'before custom method' in issues[2]


### PR DESCRIPTION
Fixes #18 

The code isn't the prettiest, mainly because I wanted to make sure the error message contained information about specifically what type of declaration that should have come before what other type of declaration. I'm sure it could be improved, but it seems to be functioning as expected at least.

This PR will clash with other PRs that claim DJ09 as the error message, but there's nothing I can do about that I suppose.

The unit tests are rudimentary for now. Ideally I'd like to use something like a custom Hypothesis strategy to automatically generate test data to verify against, but that would introduce a pretty heavy dependency and take a lot more time to implement.

I had to make a few assumptions that may or may not cause issues in real-world applications, e.g. if you assign a variable the return value of a function call, I'm assuming that it's a field definition, unless the variable is named `objects`. I'm not too well-versed in Flake8 internals, but maybe a simple `# noqa` would get around such issues? Otherwise, I think we'd have to start doing introspections on the code to make sure the return value type is an instance of `Field`, which seems tricky to me.