### PR TITLE
Fix for abstract model check

### DIFF
--- a/flake8_django/checkers/base_model_checker.py
+++ b/flake8_django/checkers/base_model_checker.py
@@ -13,8 +13,8 @@ class BaseModelChecker(Checker):
     def _is_abstract_and_set_to_true(self, element):
         return (
                 isinstance(element, ast.Assign)
-                and element.value.value is True
                 and any(target.id == 'abstract' for target in element.targets)
+                and element.value.value is True
         )
 
     def is_abstract_model(self, base):


### PR DESCRIPTION
the corresponding check will fail for translated strings, for example:

```
class MyModel(models.Model):
    class Meta:
        verbose_name =  _("My Model")

```

it's because value is checked before target name. this easily can be fixed by using only abstract target, which is much more determinated.