### PR TITLE
Bugfix: RenderChecker accesses not existing id attribute

### DIFF
--- a/flake8_django/checkers/render.py
+++ b/flake8_django/checkers/render.py
@@ -19,7 +19,7 @@ class RenderChecker(Checker):
             return
         issues = []
         for arg in node.args:
-            if isinstance(arg, ast.Call) and arg.func.id == 'locals':
+            if isinstance(arg, ast.Call) and getattr(arg.func, 'id', '') == 'locals':
                 issues.append(
                     DJ03(
                         lineno=node.lineno,


### PR DESCRIPTION
Closes #48 

@rocioar With django 2.2.9 and Python 3.6 I get the error from #48 and this solves it.

What do you need more to accept my PR? 😃 