### PR TITLE
DJ12: Enforce `related_name` on FK and M2M fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ $ pytest --cov=.
 | `DJ09` | Model must define `class Meta`|
 | `DJ10` | Class Meta from Model has to define `verbose_name`|
 | `DJ11` | Class Meta from Model has to define `verbose_name_plural`|
+| `DJ12` | Fields `ForeignKey` and `ManyToManyField` need to have a `related_name`|
 
 ## Licence
 

--- a/tests/test_model_fields.py
+++ b/tests/test_model_fields.py
@@ -1,33 +1,47 @@
 import pytest
 
-from flake8_django.checkers.model_fields import NOT_BLANK_TRUE_FIELDS, NOT_NULL_TRUE_FIELDS
+from flake8_django.checkers import model_fields
 
 from .utils import run_check, error_code_in_result
 
 
-@pytest.mark.parametrize('field_type', NOT_NULL_TRUE_FIELDS)
+@pytest.mark.parametrize('field_type', model_fields.NOT_NULL_TRUE_FIELDS)
 def test_not_null_fields_fails(field_type):
     code = "field = models.{}(null=True)".format(field_type)
     result = run_check(code)
     assert error_code_in_result('DJ01', result)
 
 
-@pytest.mark.parametrize('field_type', NOT_NULL_TRUE_FIELDS)
+@pytest.mark.parametrize('field_type', model_fields.NOT_NULL_TRUE_FIELDS)
 def test_not_null_fields_success(field_type):
     code = "field = models.{}()".format(field_type)
     result = run_check(code)
     assert not error_code_in_result('DJ01', result)
 
 
-@pytest.mark.parametrize('field_type', NOT_BLANK_TRUE_FIELDS)
+@pytest.mark.parametrize('field_type', model_fields.NOT_BLANK_TRUE_FIELDS)
 def test_not_blank_fields_fails(field_type):
     code = "another_field = models.{}(blank=True)".format(field_type)
     result = run_check(code)
     assert error_code_in_result('DJ02', result)
 
 
-@pytest.mark.parametrize('field_type', NOT_BLANK_TRUE_FIELDS)
+@pytest.mark.parametrize('field_type', model_fields.NOT_BLANK_TRUE_FIELDS)
 def test_not_blank_fields_sucess(field_type):
     code = "another_field = models.{}()".format(field_type)
     result = run_check(code)
     assert not error_code_in_result('DJ02', result)
+
+
+@pytest.mark.parametrize('field_type', model_fields.FOREIGN_KEY_FIELDS)
+def test_foreign_key_no_related_name(field_type):
+    code = "field = models.{}()".format(field_type)
+    result = run_check(code)
+    assert error_code_in_result('DJ12', result)
+
+
+@pytest.mark.parametrize('field_type', model_fields.FOREIGN_KEY_FIELDS)
+def test_foreign_key_has_related_name(field_type):
+    code = "field = models.{}(related_name='children')".format(field_type)
+    result = run_check(code)
+    assert not error_code_in_result('DJ12', result)


### PR DESCRIPTION
Hi there,

I finally made it! 

I added `DJ12` to enforce setting `related_names` on FK and M2M fields. I think this is important because at first the django default `*_set` is misleading at best. Secondly, if you have to set a related name you need activly think about the kind of relation you are creating.
Especially important for django newbies in my opinion.

Hope this makes it into the master branch :)

Best from Cologne
Ronny