### PR TITLE
Removes DJ02 check

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ $ pytest --cov=.
 | Warning | Description |
 | --- | --- |
 | `DJ01` | Using `null=True` is not recommended for some of the Django ORM fields. E.g. `CharField`, `EmailField`, `ImageField`, `FileField`, `UUIDField`, `SlugField`, `TextField` |
-| `DJ02` | Using `blank=True` is not recommended on `BooleanField`|
 | `DJ03` | Using locals() in render function is not recommended, use explicit arguments |
 | `DJ05` | URLs include() should set a namespace |
 | `DJ06` | ModelForm should not set exclude, instead it should use fields, which is an explicit list of all the fields that should be included in the form |

--- a/flake8_django/checkers/model_fields.py
+++ b/flake8_django/checkers/model_fields.py
@@ -7,7 +7,6 @@ NOT_NULL_TRUE_FIELDS = [
     'EmailField', 'UUIDField', 'ImageField',
     'FileField', 'FilePathField', 'URLField'
 ]
-NOT_BLANK_TRUE_FIELDS = ['BooleanField']
 
 
 class DJ01(Issue):
@@ -15,16 +14,11 @@ class DJ01(Issue):
     description = 'null=True not recommended to be used in {field}'
 
 
-class DJ02(Issue):
-    code = 'DJ02'
-    description = 'blank=True not recommended to be used in {field}'
-
-
 class ModelFieldChecker(Checker):
 
     def run(self, node):
         call_name = self.get_call_name(node)
-        if not(call_name in NOT_NULL_TRUE_FIELDS or call_name in NOT_BLANK_TRUE_FIELDS):
+        if call_name not in NOT_NULL_TRUE_FIELDS:
             return
 
         issues = []
@@ -32,14 +26,6 @@ class ModelFieldChecker(Checker):
             if call_name in NOT_NULL_TRUE_FIELDS and keyword.arg == 'null' and keyword.value.value is True:
                 issues.append(
                     DJ01(
-                        lineno=node.lineno,
-                        col=node.col_offset,
-                        parameters={'field': call_name}
-                    )
-                )
-            if call_name in NOT_BLANK_TRUE_FIELDS and keyword.arg == 'blank' and keyword.value.value is True:
-                issues.append(
-                    DJ02(
                         lineno=node.lineno,
                         col=node.col_offset,
                         parameters={'field': call_name}

--- a/tests/test_model_fields.py
+++ b/tests/test_model_fields.py
@@ -1,6 +1,6 @@
 import pytest
 
-from flake8_django.checkers.model_fields import NOT_BLANK_TRUE_FIELDS, NOT_NULL_TRUE_FIELDS
+from flake8_django.checkers.model_fields import NOT_NULL_TRUE_FIELDS
 
 from .utils import run_check, error_code_in_result
 
@@ -17,17 +17,3 @@ def test_not_null_fields_success(field_type):
     code = "field = models.{}()".format(field_type)
     result = run_check(code)
     assert not error_code_in_result('DJ01', result)
-
-
-@pytest.mark.parametrize('field_type', NOT_BLANK_TRUE_FIELDS)
-def test_not_blank_fields_fails(field_type):
-    code = "another_field = models.{}(blank=True)".format(field_type)
-    result = run_check(code)
-    assert error_code_in_result('DJ02', result)
-
-
-@pytest.mark.parametrize('field_type', NOT_BLANK_TRUE_FIELDS)
-def test_not_blank_fields_sucess(field_type):
-    code = "another_field = models.{}()".format(field_type)
-    result = run_check(code)
-    assert not error_code_in_result('DJ02', result)


### PR DESCRIPTION
DJ02 was applicable for Django < 2.1, since now `NullBooleanField` has been removed, we removed this check altogether.