### PR TITLE
Remove the dot from the pytest command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install dependencies
         run: pip install pytest-cov
       - name: Run Coverage
-        run: py.test --cov=.
+        run: pytest --cov=.
       - name: Upload Coverage
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Remove the dot from the pytest command
As recomended since [3.0.0](https://docs.pytest.org/en/latest/changelog.html#id1110) version