### PR TITLE
Removed UUIDField from DJ01

### DIFF
--- a/flake8_django/checkers/model_fields.py
+++ b/flake8_django/checkers/model_fields.py
@@ -4,7 +4,7 @@ from .issue import Issue
 
 NOT_NULL_TRUE_FIELDS = [
     'CharField', 'TextField', 'SlugField',
-    'EmailField', 'UUIDField', 'ImageField',
+    'EmailField', 'ImageField',
     'FileField', 'FilePathField', 'URLField'
 ]
 


### PR DESCRIPTION
When using `UUIDField(null=True)` DJ01 check fails. `UUIDField` does not inherit `CharField` and doesn't allow blank values (`""`) so there's no way to have unknown/unspecified values other than null.