### PR TITLE
Update DJ12 error message

### DIFF
--- a/flake8_django/checkers/model_content_order.py
+++ b/flake8_django/checkers/model_content_order.py
@@ -8,7 +8,7 @@ from .issue import Issue
 class DJ12(Issue):
     code = 'DJ12'
     description = (
-        "The order of the model's inner classes, methods, and fields do not follow the "
+        "The order of the model's inner classes, methods, and fields does not follow the "
         "Django Style Guide: {elem_type} should come before {before}"
     )
 

--- a/flake8_django/checkers/model_content_order.py
+++ b/flake8_django/checkers/model_content_order.py
@@ -8,7 +8,7 @@ from .issue import Issue
 class DJ12(Issue):
     code = 'DJ12'
     description = (
-        "Order of Model's inner classes, methods, and fields does not follow the"
+        "The order of the model's inner classes, methods, and fields do not follow the "
         "Django Style Guide: {elem_type} should come before {before}"
     )
 


### PR DESCRIPTION
Hi! 

First of all, thanks for making this! It's a very cool project 👏

When I was running the plugin locally, I noticed that the `DJ12` error message was missing a whitespace:

`DJ12 Order of Model's inner classes, methods, and fields does not follow theDjango Style Guide: Meta class should come before __str__ method`

This PR adds back the missing whitespace, and also alters the wording slightly. Let me know if you would like it changed in some way.