### PR TITLE
Add rule to check for explicit db_table

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ More details about each of the Rules can be found on the [wiki page](https://git
 | ---- | ----------- |
 | [`DJ10`](https://github.com/rocioar/flake8-django/wiki/%5BDJ10%5D-Model-should-define-verbose_name-on-its-Meta-inner-class) | Model should define verbose_name on its Meta inner class |
 | [`DJ11`](https://github.com/rocioar/flake8-django/wiki/%5BDJ11%5D-Model-should-define-verbose_name_plural-on-its-Meta-inner-class) | Model should define verbose_name_plural on its Meta inner class |
+| [`DJ14`](#) | Model should define db_table on its Meta inner class |
 
 To enable optional rules you can use the `--select` parameter. It's default values are: E,F,W,C90.
 

--- a/flake8_django/checker.py
+++ b/flake8_django/checker.py
@@ -13,7 +13,7 @@ from flake8_django.checkers import (
 __version__ = '1.1.5'
 
 
-CHECKS_DISABLED_BY_DEFAULT = ['DJ10', 'DJ11']
+CHECKS_DISABLED_BY_DEFAULT = ['DJ10', 'DJ11', 'DJ14']
 
 
 class DjangoStyleFinder(ast.NodeVisitor):

--- a/flake8_django/checkers/model_meta.py
+++ b/flake8_django/checkers/model_meta.py
@@ -13,6 +13,10 @@ class DJ11(Issue):
     code = 'DJ11'
     description = 'Model should define verbose_name_plural in its Meta inner class'
 
+class DJ14(Issue):
+    code = 'DJ14'
+    description = 'Model should define db_table in its Meta inner class'
+
 
 class ModelMetaChecker(BaseModelChecker):
     model_name_lookup = 'Model'
@@ -38,6 +42,9 @@ class ModelMetaChecker(BaseModelChecker):
 
     def has_verbose_name_plural(self, meta_class_node):
         return self._has_element(meta_class_node, 'verbose_name_plural')
+
+    def has_db_table(self, meta_class_node):
+        return self._has_element(meta_class_node, 'db_table')
 
     @staticmethod
     def _has_element(element, target_name):
@@ -72,6 +79,14 @@ class ModelMetaChecker(BaseModelChecker):
         if not meta_class_node or not self.has_verbose_name_plural(meta_class_node):
             issues.append(
                 DJ11(
+                    lineno=node.lineno,
+                    col=node.col_offset,
+                )
+            )
+        
+        if not meta_class_node or not self.has_db_table(meta_class_node):
+            issues.append(
+                DJ14(
                     lineno=node.lineno,
                     col=node.col_offset,
                 )


### PR DESCRIPTION
This adds a new optional rule to check for `db_table` to be explicitly declared on a model's Meta. One reason you might want to do this is that it makes moving models in bigger projects easier. A `db_table` that isn't explicitly declared will automatically include information about the django app it belongs to. In many cases this is probably desirable, such as when a third party app installs a model into your code base, you want the table names to be namespaced to the app installed. But when dealing with big Django code bases, you might want to rearrange your own models over time, to deprecate old apps or otherwise. So defining explicit db_table should ensure that, regardless of the app you're in, your model maps to the expected db_table name.

I can't update the README to include a working wiki link unless it's merged, so I just left that as a `#` for now.