### PR TITLE
Add exception handling for model field checking

### DIFF
--- a/flake8_django/checkers/model_content_order.py
+++ b/flake8_django/checkers/model_content_order.py
@@ -1,4 +1,5 @@
 import astroid
+from astroid.exceptions import InferenceError
 from functools import partial
 
 from .base_model_checker import BaseModelChecker
@@ -33,7 +34,7 @@ def is_field_declaration(node):
             ):
                 return True
         return False
-    except AttributeError:
+    except (AttributeError, InferenceError):
         return False
 
 

--- a/flake8_django/checkers/model_form.py
+++ b/flake8_django/checkers/model_form.py
@@ -24,13 +24,19 @@ class ModelFormChecker(BaseModelChecker):
         """
         Return True if element is astroid.Const, astroid.List or astroid.Tuple  and equals "__all__"
         """
-        if isinstance(element.value, (astroid.List, astroid.Tuple)):
+        assign_value = element.value
+        if not isinstance(
+            assign_value,
+            (astroid.List, astroid.Tuple, astroid.Const),
+        ):
+            return False
+        if isinstance(assign_value, (astroid.List, astroid.Tuple)):
             return any(
                 iter_item.value == '__all__'
-                for iter_item in element.value.itered()
+                for iter_item in assign_value.itered()
             )
         else:
-            node_value = element.value.value
+            node_value = assign_value.value
             if isinstance(node_value, bytes):
                 node_value = node_value.decode()
             return node_value == '__all__'

--- a/tests/fixtures/model_content_order.py
+++ b/tests/fixtures/model_content_order.py
@@ -102,3 +102,27 @@ class PerfectlyFine(models.Model):
     @property
     def random_property(self):
         return '%s' % self
+
+
+class CustomManager(models.Manager):
+    def manager_only_method(self):
+        return
+
+
+class CustomQuerySet(models.QuerySet):
+    def manager_and_queryset_method(self):
+        return
+
+
+class ModelWithCustomManager(models.Model):
+    """
+    Model with custom manager which can't be inferred correctly.
+    """
+    first_name = models.CharField(max_length=32)
+    objects = CustomManager.from_queryset(CustomQuerySet)()
+    class Meta:
+        verbose_name = 'test'
+        verbose_name_plural = 'tests'
+
+    def __str__(self):
+        return 'Perfectly fine!'

--- a/tests/fixtures/model_form_fields.py
+++ b/tests/fixtures/model_form_fields.py
@@ -11,3 +11,8 @@ class User(ModelForm):
 
         def test_method_doesnt_error(self):
             pass
+
+
+class ExtendedUser(User):
+    class Meta(User.Meta):
+        fields = User.Meta.fields + ('email',)

--- a/tests/fixtures/model_form_fields_all.py
+++ b/tests/fixtures/model_form_fields_all.py
@@ -26,4 +26,3 @@ class User5(ModelForm):
     class Meta:
         model = User2
         fields = ['__all__']
-


### PR DESCRIPTION
Resolve: #115
Some of model attributes which are not fields (custom managers for example) cannot be inspected by `astroid` properly therefore we need to add additional `InferenceError` to `try-except` construction.

Resolve: #117 
 Add node type checking to handle cases when there're binary operations for `field` attr of `Meta` class. For example:
 ```
class ExtendedUserForm(UserForm):
    class Meta(UserForm):
        fields = UserForm.Meta.fields + ('email',)
```
