### PR TITLE
fix: find __str__ from abstract model

### DIFF
--- a/tests/fixtures/model_dunder_str_inherited_from_abstract_model.py
+++ b/tests/fixtures/model_dunder_str_inherited_from_abstract_model.py
@@ -1,0 +1,23 @@
+from django.db import models
+from django.db.models import Model
+
+
+class AbstractTestModel(Model):
+    new_field = models.CharField(max_length=10)
+
+    class Meta:
+        abstract = True
+
+    def __str__(self):
+        return self.new_field
+
+    @property
+    def my_brand_new_property(self):
+        return 1
+
+    def my_beautiful_method(self):
+        return 2
+
+
+class TestModel(AbstractTestModel):
+    pass

--- a/tests/test_model_dunder_str.py
+++ b/tests/test_model_dunder_str.py
@@ -29,3 +29,13 @@ def test_abstract_model_with_dunder_str_method_success():
     code = load_fixture_file('abstract_model_dunder_str.py')
     result = run_check(code)
     assert not error_code_in_result('DJ08', result)
+
+
+def test_model_dunder_str_inherited_from_abstract_model():
+    """
+    A concrete model with an inherited __str__ method from an sbstract model succeeds.
+    """
+    code = load_fixture_file('model_dunder_str_inherited_from_abstract_model.py')
+    result = run_check(code)
+
+    assert not error_code_in_result('DJ08', result)


### PR DESCRIPTION
Finds `__str__` in abstract models.

Partially addresses #119 

