### PR TITLE
Add rule to check for relationship field

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ More details about each of the Rules can be found on the [wiki page](https://git
 | ---- | ----------- |
 | [`DJ10`](https://github.com/rocioar/flake8-django/wiki/%5BDJ10%5D-Model-should-define-verbose_name-on-its-Meta-inner-class) | Model should define verbose_name on its Meta inner class |
 | [`DJ11`](https://github.com/rocioar/flake8-django/wiki/%5BDJ11%5D-Model-should-define-verbose_name_plural-on-its-Meta-inner-class) | Model should define verbose_name_plural on its Meta inner class |
+| [`DJ21`](#) | Pass the model name as a string on relationship fields |
+| [`DJ22`](#) | Use get_user_model() instead of models.User on relationship fields |
+
+
 
 To enable optional rules you can use the `--select` parameter. It's default values are: E,F,W,C90.
 

--- a/flake8_django/checker.py
+++ b/flake8_django/checker.py
@@ -7,12 +7,13 @@ import astroid
 from flake8_django.checkers import (DecoratorChecker, ModelContentOrderChecker,
                                     ModelDunderStrMissingChecker,
                                     ModelFieldChecker, ModelFormChecker,
-                                    ModelMetaChecker, RenderChecker)
+                                    ModelMetaChecker, RenderChecker,
+                                    ModelRelationshipFieldChecker)
 
 __version__ = '1.1.5'
 
 
-CHECKS_DISABLED_BY_DEFAULT = ['DJ10', 'DJ11']
+CHECKS_DISABLED_BY_DEFAULT = ['DJ10', 'DJ11', 'DJ21', 'DJ22']
 
 
 class DjangoStyleFinder(ast.NodeVisitor):
@@ -23,6 +24,7 @@ class DjangoStyleFinder(ast.NodeVisitor):
         'Call': [
             ModelFieldChecker(),
             RenderChecker(),
+            ModelRelationshipFieldChecker(),
         ],
         'FunctionDef': [
             DecoratorChecker(),

--- a/flake8_django/checkers/__init__.py
+++ b/flake8_django/checkers/__init__.py
@@ -2,6 +2,7 @@ from .decorator import DecoratorChecker
 from .model_content_order import ModelContentOrderChecker
 from .model_dunder_str import ModelDunderStrMissingChecker
 from .model_fields import ModelFieldChecker
+from .model_relationship_fields import ModelRelationshipFieldChecker
 from .model_form import ModelFormChecker
 from .render import RenderChecker
 from .model_meta import ModelMetaChecker
@@ -9,5 +10,5 @@ from .model_meta import ModelMetaChecker
 __all__ = [
     'DecoratorChecker', 'ModelDunderStrMissingChecker', 'ModelFieldChecker',
     'ModelFormChecker', 'RenderChecker', 'ModelMetaChecker',
-    'ModelContentOrderChecker'
+    'ModelContentOrderChecker', "ModelRelationshipFieldChecker",
 ]

--- a/flake8_django/checkers/model_relationship_fields.py
+++ b/flake8_django/checkers/model_relationship_fields.py
@@ -1,0 +1,53 @@
+import ast
+
+from .checker import Checker
+from .issue import Issue
+
+
+RELATIONSHIP_FIELDS = ['ForeignKey', 'ManyToManyField', 'OneToOneField']
+
+
+class DJ21(Issue):
+    code = 'DJ21'
+    description = 'Pass the model name as a string on relationship fields such {field}.'
+
+class DJ22(Issue):
+    code = 'DJ22'
+    description = 'Use get_user_model() instead of models.User on relationship fields such {field}.'
+
+
+
+class ModelRelationshipFieldChecker(Checker):
+
+    def run(self, node):
+        call_name = self.get_call_name(node)
+        if call_name not in RELATIONSHIP_FIELDS:
+            return
+
+        issues = []
+        for keyword in node.keywords:
+            if keyword.arg == 'to':
+                if not isinstance(keyword.value, ast.Call) and not isinstance(getattr(keyword.value, 'value', None), str):
+                    issues.append(
+                        DJ21(
+                            lineno=node.lineno,
+                            col=node.col_offset,
+                            parameters={'field': call_name}
+                        )
+                    )
+                if (
+                    getattr(keyword.value, 'value', None) in ['models.User', 'User']
+                    or getattr(keyword.value, 'attr', None) == 'User'
+                    or getattr(keyword.value, 'id', None) == 'User'
+                ):
+                    issues.append(
+                        DJ22(
+                            lineno=node.lineno,
+                            col=node.col_offset,
+                            parameters={'field': call_name}
+                        )
+                    )
+
+
+        return issues
+

--- a/tests/test_model_relationship_fields.py
+++ b/tests/test_model_relationship_fields.py
@@ -1,0 +1,54 @@
+import pytest
+
+from flake8_django.checkers.model_relationship_fields import RELATIONSHIP_FIELDS
+
+from .utils import run_check, error_code_in_result
+
+
+RELATIONSHIP_FIELDS_TO = ['apps_name.CheckModel', 'CheckModel']
+RELATIONSHIP_FIELDS_USER_TO = ['models.User', 'User']
+
+@pytest.mark.parametrize('to', RELATIONSHIP_FIELDS_TO)
+@pytest.mark.parametrize('field_type', RELATIONSHIP_FIELDS)
+def test_string_binding_is_used(field_type, to):
+    code = "field = models.{}(to={})".format(field_type, to)
+    result = run_check(code)
+    assert error_code_in_result('DJ21', result)
+
+
+@pytest.mark.parametrize('to', RELATIONSHIP_FIELDS_TO)
+@pytest.mark.parametrize('field_type', RELATIONSHIP_FIELDS)
+def test_string_binding_is_used_not_raise_an_error(field_type, to):
+    code = "field = models.{}(to='{}')".format(field_type, to)
+    result = run_check(code)
+    assert not error_code_in_result('DJ21', result)
+
+
+@pytest.mark.parametrize('field_type', RELATIONSHIP_FIELDS)
+def test_function_binding_is_used_not_raise_an_error(field_type):
+    code = "field = models.{}(to=get_model())".format(field_type)
+    result = run_check(code)
+    assert not error_code_in_result('DJ21', result)
+
+
+@pytest.mark.parametrize('to', RELATIONSHIP_FIELDS_USER_TO)
+@pytest.mark.parametrize('field_type', RELATIONSHIP_FIELDS)
+def test_get_user_model_is_not_used_is_string(field_type, to):
+    code = "field = models.{}(to='{}')".format(field_type, to)
+    result = run_check(code)
+    assert error_code_in_result('DJ22', result)
+
+
+@pytest.mark.parametrize('to', RELATIONSHIP_FIELDS_USER_TO)
+@pytest.mark.parametrize('field_type', RELATIONSHIP_FIELDS)
+def test_get_user_model_is_not_used_is_module(field_type, to):
+    code = "field = models.{}(to={})".format(field_type, to)
+    result = run_check(code)
+    assert error_code_in_result('DJ22', result)
+
+
+@pytest.mark.parametrize('field_type', RELATIONSHIP_FIELDS)
+def test_get_user_is_used(field_type):
+    code = "field = models.{}(to=get_user_model())".format(field_type)
+    result = run_check(code)
+    assert not error_code_in_result('DJ22', result)


### PR DESCRIPTION
Added two optional rules to validate the relationship field. 
DJ21 - Check that the model name is present as strings. This allows us to reduce the consequences of cyclical imports. 
DJ22 - Checking that get_user_model() is used instead of `models.User`, which is preferred by Django developers

Need to edit wiki links in README.md while in use (#)

My English is not very good, if I made a mistake somewhere, please correct me.